### PR TITLE
Added Texture Cache to significantly speed up loading textures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+texture_cache.pbz2

--- a/src/craftax/constants.py
+++ b/src/craftax/constants.py
@@ -1,13 +1,12 @@
 import os
 import pathlib
 from enum import Enum
-
 import jax.numpy as jnp
 import imageio.v3 as iio
 import numpy as np
 from PIL import Image
-
 from craftax.util.maths_utils import get_distance_map
+from environment_base.util import load_compressed_pickle, save_compressed_pickle
 
 # GAME CONSTANTS
 OBS_DIM = (9, 11)
@@ -16,7 +15,7 @@ MAX_OBS_DIM = max(OBS_DIM)
 BLOCK_PIXEL_SIZE_HUMAN = 64
 BLOCK_PIXEL_SIZE_AGENT = 7
 INVENTORY_OBS_HEIGHT = 4
-
+TEXTURE_CACHE_FILE = os.path.join(pathlib.Path(__file__).parent.resolve(), "assets", "texture_cache.pbz2")
 
 # ENUMS
 class BlockType(Enum):
@@ -1109,7 +1108,11 @@ def load_all_textures(block_pixel_size):
     }
 
 
-TEXTURES = {
-    BLOCK_PIXEL_SIZE_AGENT: load_all_textures(BLOCK_PIXEL_SIZE_AGENT),
-    BLOCK_PIXEL_SIZE_HUMAN: load_all_textures(BLOCK_PIXEL_SIZE_HUMAN),
-}
+if os.path.exists(TEXTURE_CACHE_FILE):
+    TEXTURES = load_compressed_pickle(TEXTURE_CACHE_FILE)
+else:
+    TEXTURES = {
+        BLOCK_PIXEL_SIZE_AGENT: load_all_textures(BLOCK_PIXEL_SIZE_AGENT),
+        BLOCK_PIXEL_SIZE_HUMAN: load_all_textures(BLOCK_PIXEL_SIZE_HUMAN),
+    }
+    save_compressed_pickle(TEXTURE_CACHE_FILE, TEXTURES)

--- a/src/craftax/constants.py
+++ b/src/craftax/constants.py
@@ -13,6 +13,7 @@ OBS_DIM = (9, 11)
 assert OBS_DIM[0] % 2 == 1 and OBS_DIM[1] % 2 == 1
 MAX_OBS_DIM = max(OBS_DIM)
 BLOCK_PIXEL_SIZE_HUMAN = 64
+BLOCK_PIXEL_SIZE_IMG   = 16
 BLOCK_PIXEL_SIZE_AGENT = 7
 INVENTORY_OBS_HEIGHT = 4
 TEXTURE_CACHE_FILE = os.path.join(pathlib.Path(__file__).parent.resolve(), "assets", "texture_cache.pbz2")
@@ -1113,6 +1114,7 @@ if os.path.exists(TEXTURE_CACHE_FILE):
 else:
     TEXTURES = {
         BLOCK_PIXEL_SIZE_AGENT: load_all_textures(BLOCK_PIXEL_SIZE_AGENT),
+        BLOCK_PIXEL_SIZE_IMG: load_all_textures(BLOCK_PIXEL_SIZE_IMG),
         BLOCK_PIXEL_SIZE_HUMAN: load_all_textures(BLOCK_PIXEL_SIZE_HUMAN),
     }
     save_compressed_pickle(TEXTURE_CACHE_FILE, TEXTURES)

--- a/src/craftax_classic/constants.py
+++ b/src/craftax_classic/constants.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 import imageio.v3 as iio
 import numpy as np
 from PIL import Image, ImageEnhance
+from environment_base.util import load_compressed_pickle, save_compressed_pickle
 
 # GAME CONSTANTS
 OBS_DIM = (7, 9)
@@ -15,7 +16,7 @@ assert OBS_DIM[0] % 2 == 1 and OBS_DIM[1] % 2 == 1
 BLOCK_PIXEL_SIZE_HUMAN = 64
 BLOCK_PIXEL_SIZE_AGENT = 7
 INVENTORY_OBS_HEIGHT = 2
-
+TEXTURE_CACHE_FILE = os.path.join(pathlib.Path(__file__).parent.resolve(), "assets", "texture_cache.pbz2")
 
 # ENUMS
 class BlockType(Enum):
@@ -429,8 +430,11 @@ def load_all_textures(block_pixel_size):
         "night_noise_intensity_texture": night_noise_intensity_texture,
     }
 
-
-TEXTURES = {
-    BLOCK_PIXEL_SIZE_AGENT: load_all_textures(BLOCK_PIXEL_SIZE_AGENT),
-    BLOCK_PIXEL_SIZE_HUMAN: load_all_textures(BLOCK_PIXEL_SIZE_HUMAN),
-}
+if os.path.exists(TEXTURE_CACHE_FILE):
+    TEXTURES = load_compressed_pickle(TEXTURE_CACHE_FILE)
+else:
+    TEXTURES = {
+        BLOCK_PIXEL_SIZE_AGENT: load_all_textures(BLOCK_PIXEL_SIZE_AGENT),
+        BLOCK_PIXEL_SIZE_HUMAN: load_all_textures(BLOCK_PIXEL_SIZE_HUMAN),
+    }
+    save_compressed_pickle(TEXTURE_CACHE_FILE, TEXTURES)

--- a/src/environment_base/util.py
+++ b/src/environment_base/util.py
@@ -1,0 +1,12 @@
+import pickle
+import bz2
+from typing import Any
+
+def save_compressed_pickle(title: str, data: Any):
+    with bz2.BZ2File(title, 'w') as f: 
+        pickle.dump(data, f)
+
+def load_compressed_pickle(file: str):
+    data = bz2.BZ2File(file, 'rb')
+    data = pickle.load(data)
+    return data


### PR DESCRIPTION
The first time textures are loaded into an array, the array will be stored so that subsequent runs can load the textures more quickly.