### PR TITLE
Fixed environment import bug on play scripts

### DIFF
--- a/src/play_craftax.py
+++ b/src/play_craftax.py
@@ -20,7 +20,7 @@ from craftax.constants import (
     Action,
     Achievement,
 )
-from craftax.envs.craftax_symbolic_env import CraftaxEnv
+from craftax.envs.craftax_symbolic_env import CraftaxSymbolicEnv as CraftaxEnv
 from environment_base.wrappers import AutoResetEnvWrapper
 from craftax.renderer import render_craftax_pixels
 

--- a/src/play_craftax_classic.py
+++ b/src/play_craftax_classic.py
@@ -11,7 +11,7 @@ from craftax_classic.constants import (
     Achievement,
     BLOCK_PIXEL_SIZE_HUMAN,
 )
-from craftax_classic.envs.craftax_symbolic_env import CraftaxEnv
+from craftax_classic.envs.craftax_symbolic_env import CraftaxClassicSymbolicEnv as CraftaxEnv
 from craftax_classic.renderer import render_craftax_pixels
 
 KEY_MAPPING = {


### PR DESCRIPTION
Both play scripts attempted to import an environment class that does not exist, so I've updated it to use the actual environment classes.