### PR TITLE
add PPO-GTrXL baseline in scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ We report reward as a % of the maximum (226).
 ## Craftax-1B
 | Algorithm | Reward (% max) |                                              Code                                               |                  Paper                  |
 |:----------|---------------:|:-----------------------------------------------------------------------------------------------:|:---------------------------------------:|
+| PPO-GTrXL |           18.3 | [TransformerXL_PPO_JAX](https://github.com/Reytuag/transformerXL_PPO_JAX)                       | [PPO](https://arxiv.org/abs/1707.06347), [GTrXL](https://arxiv.org/abs/1910.06764)| 
 | PPO-RNN   |           15.3 | [Craftax_Baselines](https://github.com/MichaelTMatthews/Craftax_Baselines/blob/main/ppo_rnn.py) | [PPO](https://arxiv.org/abs/1707.06347) |
 | RND       |           12.0 | [Craftax_Baselines](https://github.com/MichaelTMatthews/Craftax_Baselines/blob/main/ppo_rnd.py) | [RND](https://arxiv.org/abs/1810.12894) |
 | PPO       |           11.9 |   [Craftax_Baselines](https://github.com/MichaelTMatthews/Craftax_Baselines/blob/main/ppo.py)   | [PPO](https://arxiv.org/abs/1707.06347) |


### PR DESCRIPTION
In the scoreboard, add PPO-GTrXL baseline from https://github.com/Reytuag/transformerXL_PPO_JAX