### PR TITLE
Ensure a 4-dimensional image is loaded

### DIFF
--- a/craftax/craftax/constants.py
+++ b/craftax/craftax/constants.py
@@ -593,7 +593,7 @@ TORCH_LIGHT_MAP = jnp.clip(1 - TORCH_LIGHT_MAP, 0.0, 1.0)
 # TEXTURES
 def load_texture(filename, block_pixel_size):
     filename = os.path.join(pathlib.Path(__file__).parent.resolve(), "assets", filename)
-    img = iio.imread(filename)
+    img = iio.imread(filename, mode="RGBA")
     jnp_img = jnp.array(img).astype(int)
     assert jnp_img.shape[:2] == (16, 16)
 

--- a/craftax/craftax_classic/constants.py
+++ b/craftax/craftax_classic/constants.py
@@ -132,7 +132,7 @@ class Achievement(Enum):
 # TEXTURES
 def load_texture(filename, block_pixel_size, clamp_alpha=True):
     filename = os.path.join(pathlib.Path(__file__).parent.resolve(), "assets", filename)
-    img = iio.imread(filename)
+    img = iio.imread(filename, mode="RGBA")
     jnp_img = jnp.array(img).astype(int)
     assert jnp_img.shape[:2] == (16, 16)
 
@@ -176,12 +176,12 @@ def load_all_textures(block_pixel_size):
 
     block_textures = jnp.array(
         [
-            load_texture("debug_tile.png", block_pixel_size),
+            load_texture("debug_tile.png", block_pixel_size)[:, :, :3],
             jnp.ones((block_pixel_size, block_pixel_size, 3), dtype=jnp.int32) * 128,
-            load_texture("grass.png", block_pixel_size),
-            load_texture("water.png", block_pixel_size),
-            load_texture("stone.png", block_pixel_size),
-            load_texture("tree.png", block_pixel_size),
+            load_texture("grass.png", block_pixel_size)[:, :, :3],
+            load_texture("water.png", block_pixel_size)[:, :, :3],
+            load_texture("stone.png", block_pixel_size)[:, :, :3],
+            load_texture("tree.png", block_pixel_size)[:, :, :3],
             load_texture("wood.png", block_pixel_size)[:, :, :3],
             load_texture("path.png", block_pixel_size)[:, :, :3],
             load_texture("coal.png", block_pixel_size)[:, :, :3],


### PR DESCRIPTION
Prevents the following crash when loading textures for the first time (on macOS at least) with the command `play_craftax`.

```
File "./craftax/craftax/constants.py", line 600, in load_texture
    if jnp_img.shape[2] == 4:
IndexError: tuple index out of range
```